### PR TITLE
Create gpgme_set_global_flag wrapper

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1608,6 +1608,11 @@ GpgME::Error GpgME::checkEngine(GpgME::Engine engine)
     return Error(gpgme_engine_check_version(p));
 }
 
+int GpgME::setGlobalFlag(const char *name, const char *value)
+{
+    return gpgme_set_global_flag(name, value);
+}
+
 static const unsigned long supported_features = 0
         | GpgME::ValidatingKeylistModeFeature
         | GpgME::CancelOperationFeature

--- a/src/global.h
+++ b/src/global.h
@@ -86,6 +86,8 @@ GPGMEPP_EXPORT EngineInfo engineInfo(Engine engine);
 GPGMEPP_EXPORT Error checkEngine(Protocol proto);
 GPGMEPP_EXPORT Error checkEngine(Engine engine);
 
+GPGMEPP_EXPORT int setGlobalFlag(const char *name, const char *value);
+
 GPGMEPP_EXPORT GIOChannel *getGIOChannel(int fd);
 GPGMEPP_EXPORT QIODevice   *getQIODevice(int fd);
 


### PR DESCRIPTION
This introduces a way to call gpgme_set_global_flag for users of gpgmepp. E.g., this
might be required to set install path on WIndows.